### PR TITLE
feat: update check-nginx-wide-range stages names SD-1188

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: check-toml

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
     description: prevents from committing nginx configs with wide `try_files` directives without disabled locations
     entry: check-nginx-wide-range
     language: python
-    stages: [commit, push, manual]
+    stages: [pre-commit, pre-push, manual]
     require_serial: true

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ location ~ ^/(app/|vendor|src|tests|vagrant|docs|phpunit|svn|git|docker|migratio
 ```.pre-commit-config.yaml
 repos:
   - repo: https://github.com/saritasa-nest/saritasa-pre-commit-hooks
-    rev: 0.0.1
+    rev: 0.0.2
     hooks:
       - id: check-nginx-wide-range
         args:
@@ -45,7 +45,7 @@ Examples:
 ```.pre-commit-config.yaml
 repos:
   - repo: https://github.com/saritasa-nest/saritasa-pre-commit-hooks
-    rev: 0.0.1
+    rev: 0.0.2
     hooks:
       - id: check-nginx-wide-range
         args:
@@ -60,7 +60,7 @@ Examples:
 ```.pre-commit-config.yaml
 repos:
   - repo: https://github.com/saritasa-nest/saritasa-pre-commit-hooks
-    rev: 0.0.1
+    rev: 0.0.2
     hooks:
       - id: check-nginx-wide-range
         args:
@@ -77,7 +77,7 @@ Examples:
 ```.pre-commit-config.yaml
 repos:
   - repo: https://github.com/saritasa-nest/saritasa-pre-commit-hooks
-    rev: 0.0.1
+    rev: 0.0.2
     hooks:
       - id: check-nginx-wide-range
         args:


### PR DESCRIPTION
### Summary

Task: [SD-1188](https://saritasa.atlassian.net/browse/SD-1188)

- updated `pre-commit-hooks` version from `v4.1.0` to `v5.0.0`
- updated  `check-nginx-wide-range` stages names

Fixes such a warning
![image](https://github.com/user-attachments/assets/5f4bcee7-2048-41d4-ba47-f816a1d8c35a)

Related PRs:
- https://github.com/saritasa-nest/usummit-cms/pull/461
- https://github.com/saritasa-nest/tfaa-backend/pull/156
- https://github.com/saritasa-nest/usummit-backend/pull/795
- https://github.com/saritasa-nest/usummit-public-calendar/pull/38

Proofs, that the pre-commit hook doesn't raise any errors:

- in usummit-cms repo
  ![image](https://github.com/user-attachments/assets/ca0ee089-ed51-4c9e-a2fa-a79f550df057)
- in tfaa-backend repo
  ![image](https://github.com/user-attachments/assets/f1be187d-d457-4d37-a60f-29efbd192b4e)
- in usummit-backend repo
  ![image](https://github.com/user-attachments/assets/84132369-9caa-4b51-8fe4-99c36a85530e)
- in usummit-public-calendar
  ![image](https://github.com/user-attachments/assets/61002e78-f1ab-459c-8f6a-c117c0eaac7d)

[SD-1188]: https://saritasa.atlassian.net/browse/SD-1188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ