### PR TITLE
feat: improve error messages and docs for kyverno-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ all tests on every commit. The test for a policy will be selected for running if
 - the corresponding policy is added or changed;
 - a file related to the policy test is added, changed, or deleted.
 
+> [!IMPORTANT]
+> The CLI tool for Kyverno must be available locally.
+> Learn about various installation methods in the [documentation](https://kyverno.io/docs/kyverno-cli/install/).
+
 #### Configuration example
 
 The basic configuration for the hook has the following form:

--- a/pre_commit_hooks/kubernetes/kyverno/kyverno_test/README.md
+++ b/pre_commit_hooks/kubernetes/kyverno/kyverno_test/README.md
@@ -17,6 +17,15 @@ Install [pyenv](https://github.com/pyenv/pyenv#installation) and
 ➜ pyenv activate saritasa-pre-commit-hooks  # not necessary with shell integration
 ```
 
+The CLI tool for Kyverno must be available locally. It can be installed via `brew`:
+
+```
+➜ brew install kyverno
+```
+
+More installation options are described in the
+[documentation](https://kyverno.io/docs/kyverno-cli/install/).
+
 ### Dependencies
 
 The project dependencies can be installed by running the following command in

--- a/pre_commit_hooks/kubernetes/kyverno/kyverno_test/main.py
+++ b/pre_commit_hooks/kubernetes/kyverno/kyverno_test/main.py
@@ -2,6 +2,7 @@ import argparse
 import subprocess
 from collections.abc import Sequence
 from pathlib import Path
+from shutil import which
 
 from pre_commit_hooks.util import get_changed_files, get_deleted_files
 
@@ -93,8 +94,11 @@ class Hook:
             path: A path to the test directory.
 
         Raises:
+            ValidationError: If kyverno CLI binary is not available locally.
             KyvernoTestError: If any error or warning is encountered, including test failure.
         """
+        if not which("kyverno"):
+            raise ValidationError("kyverno CLI tool is not available, see https://kyverno.io/docs/kyverno-cli/install/")
         command = [
             "kyverno",
             "test",


### PR DESCRIPTION
### Summary

Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)

Changes:
- add installation instructions for the `kyverno` CLI tool
- improve the error message for missing `kyverno` binary

Once this PR is merged, I'll update the `0.0.5` tag. For now this fix is available in `0.0.6-alpha.1`.

### Example

<img width="495" height="106" src="https://github.com/user-attachments/assets/a8955013-f1d2-4227-821b-ca4f20a4d580" />

<img width="732" height="195" src="https://github.com/user-attachments/assets/27167d6e-a5a6-491b-a0c2-ec29688c9827" />

[SD-373]: https://saritasa.atlassian.net/browse/SD-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ