### PR TITLE
Fix adding task number to repo without commits

### DIFF
--- a/pre_commit_hooks/add_task_number/cli.py
+++ b/pre_commit_hooks/add_task_number/cli.py
@@ -17,7 +17,7 @@ def parse_args(argv=None):
     )
     parser.add_argument(
         "--branch-regex",
-        default=r"^(feature|fix)/(?P<task>[A-Z0-9]+-[0-9]+)-.*",
+        default=r"^(feature|fix|hotfix)/(?P<task>[A-Z0-9]+-[0-9]+)-.*",
         type=str,
         help=(
             "Regex to get task number from the branch name. "

--- a/pre_commit_hooks/util.py
+++ b/pre_commit_hooks/util.py
@@ -64,7 +64,7 @@ def git_commit(commit_msg: str):
 
 def get_current_branch() -> str:
     """Return current branch's name."""
-    return cmd_output("git", "rev-parse", "--abbrev-ref", "HEAD")
+    return cmd_output("git", "symbolic-ref", "--short", "HEAD")
 
 
 def get_git_config_param(param: str) -> str | None:


### PR DESCRIPTION
It is needed to use `git symbolic-ref --short HEAD` instead of `git rev-parse --abbrev-ref HEAD` to avoid errors in repos without commits.

Also updated default branch regex to include `hotfix` branches.

Task: SA3P-22