### PR TITLE
Fix `add-task-number` for interactive rebases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         name: isort (python)
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         exclude: node_modules|migrations|scripts|.venv|__init__.py

--- a/README.md
+++ b/README.md
@@ -267,3 +267,34 @@ use the following flag.
     # ...
     - --disable-strict-mode
 ```
+
+## Local development
+
+Prepare local dev environment using [uv](https://github.com/astral-sh/uv#installation)
+with any supported Python version (`3.10+`), for example::
+
+```console
+uv venv --python 3.14 --prompt pre-commit-hooks --seed
+uv pip install -r requirements.txt
+uv pip install -r pre_commit_hooks/kubernetes/kyverno/kyverno_test/requirements.txt
+source .venv/bin/activate
+```
+
+Setup [prek](https://prek.j178.dev/) hooks:
+
+```console
+uv pip install prek
+prek install --hook-type pre-commit --hook-type pre-push --hook-type commit-msg
+```
+
+### Run tests
+
+```console
+pytest
+```
+
+### Run all pre-commit hooks
+
+```console
+prek run --stage pre-push --all-files
+```

--- a/pre_commit_hooks/add_task_number/main.py
+++ b/pre_commit_hooks/add_task_number/main.py
@@ -72,8 +72,10 @@ def strip_comment_section(message: str) -> str:
 def add_task_number(filename: str, branch_regex: str, format_template: str):
     """Provide task number to commit message."""
     branch = get_current_branch()
-    task_number = retrieve_task(branch, branch_regex)
+    if not branch:
+        return
 
+    task_number = retrieve_task(branch, branch_regex)
     if not task_number:
         return
 

--- a/pre_commit_hooks/util.py
+++ b/pre_commit_hooks/util.py
@@ -62,9 +62,16 @@ def git_commit(commit_msg: str):
     )
 
 
-def get_current_branch() -> str:
-    """Return current branch's name."""
-    return cmd_output("git", "symbolic-ref", "--short", "HEAD")
+def get_current_branch() -> str | None:
+    """Return current branch's name if it can be found."""
+    try:
+        return cmd_output("git", "symbolic-ref", "--short", "HEAD")
+    except RuntimeError:
+        # If symbolic-ref fails (e.g., detached HEAD), fall back to name-rev
+        try:
+            return cmd_output("git", "name-rev", "--name-only", "HEAD")
+        except RuntimeError:
+            return None
 
 
 def get_git_config_param(param: str) -> str | None:
@@ -118,7 +125,7 @@ def strip_comment_section(message: str) -> str:
 
 
 def get_changed_files() -> set[str]:
-    """Retrieves a set of all staged files except the deleted ones."""
+    """Retrieve a set of all staged files except the deleted ones."""
     cmd = (
         "git",
         "diff",
@@ -126,19 +133,19 @@ def get_changed_files() -> set[str]:
         "--name-only",
         "--no-ext-diff",
         # D (Deleted) is excluded
-        "--diff-filter=ACMRTUXB"
+        "--diff-filter=ACMRTUXB",
     )
     return set(cmd_output(*cmd).splitlines())
 
 
 def get_deleted_files() -> set[str]:
-    """Retrieves a set of the deleted staged files."""
+    """Retrieve a set of the deleted staged files."""
     cmd = (
         "git",
         "diff",
         "--staged",
         "--name-only",
         "--no-ext-diff",
-        "--diff-filter=D"
+        "--diff-filter=D",
     )
     return set(cmd_output(*cmd).splitlines())

--- a/tests/test_add_task_number.py
+++ b/tests/test_add_task_number.py
@@ -1,3 +1,7 @@
+import os
+import shlex
+import sys
+
 import pytest
 
 from pre_commit_hooks import util as base_util
@@ -144,3 +148,58 @@ def test_commit_message_will_not_be_modified_for_wrong_branch(
             last_commit_message = commit_msg_file.read()
 
         assert last_commit_message == expected_commit_message
+
+
+def test_add_task_number_during_amend_in_interactive_rebase(
+    temp_git_dir,
+    branch_regex,
+    format_template,
+):
+    """Check task and `git commit --amend` during interactive rebase."""
+    with temp_git_dir.as_cwd():
+        base_util.git_commit("Init commit")
+        base_util.git_create_branch("feature/ABC-123-my-beautiful-branch")
+        base_util.git_commit("First commit")
+        base_util.git_commit("Second commit")
+
+        # Perform `git rebase -i HEAD~2` and change
+        # `pick` to `edit` for the first commit
+        sequence_editor = " ".join(
+            [
+                shlex.quote(sys.executable),
+                "-c",
+                shlex.quote(
+                    "from pathlib import Path; "
+                    "import sys; "
+                    "todo_path = Path(sys.argv[1]); "
+                    "lines = todo_path.read_text().splitlines(); "
+                    "lines[0] = lines[0].replace('pick ', 'edit ', 1); "
+                    "todo_path.write_text('\\n'.join(lines) + '\\n')",
+                ),
+            ],
+        )
+        base_util.cmd_output(
+            "git",
+            "rebase",
+            "-i",
+            "HEAD~2",
+            env={
+                **os.environ,
+                "GIT_SEQUENCE_EDITOR": sequence_editor,
+            },
+        )
+
+        commit_msg_file_path = f"{temp_git_dir}/.git/COMMIT_EDITMSG"
+        with open(commit_msg_file_path, "w") as commit_msg_file:
+            commit_msg_file.write("Updated First commit")
+
+        main.add_task_number(
+            filename=commit_msg_file_path,
+            branch_regex=branch_regex,
+            format_template=format_template,
+        )
+
+        with open(commit_msg_file_path, "r") as commit_msg_file:
+            last_commit_message = commit_msg_file.read()
+
+        assert last_commit_message == "Updated First commit\n\nTask: ABC-123"


### PR DESCRIPTION
Previously it failed with error:
<img width="1376" height="294" alt="image" src="https://github.com/user-attachments/assets/4facd029-7ecc-4c6a-8675-b7163ed5eb4f" />


Also add instructions to simplify local development (however, 1 `kyverno-test` test failed before any changes).
Had to update `flake8` version to support Python 3.14